### PR TITLE
ci: publish releases to IPFS

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,36 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - 'main'
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Use Node.js 18
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+
+      - name: Install npm deps
+        run: npm ci
+
+      - name: Build
+        run: cd packages/ui && npm run build
+
+      - uses: aquiladev/ipfs-action@v0.3.1
+        with:
+          path: ./packages/ui/build
+          timeout: 300000
+          service: ipfs
+          pin: true
+          host: ipfs-api.apyos.dev
+          protocol: https
+          port: 443
+          headers: '{ "Authorization": "${{ secrets.IPFS_AUTHORIZATION }}" }'
+          key: kurate-ui


### PR DESCRIPTION
Some notes:
- I used `npm ci` as IIRC the issue only happens with `hardhat`, which is not used to build the UI
- I removed `fetch-depth: 0` because I don't see why we would need that (should also be removed from the check workflow I think?)
- It uses a node I run because it's necessary to be able to sign IPNS records

I'm not sure if `npm ci` is enough to build the project at this stage, but as far as I can tell `download:snark-artifacts` is only for contracts and `npx playwright install` just for testing?