### PR TITLE
style: tweaks to pages and components on persona creation flow

### DIFF
--- a/packages/ui/src/lib/components/header.svelte
+++ b/packages/ui/src/lib/components/header.svelte
@@ -82,13 +82,14 @@
 			font-size: 18px;
 			font-style: normal;
 			text-align: center;
+			line-height: 245%;
 		}
 
 		&.scrolled {
-			box-shadow: 0 6px 6px -6px rgba(var(--color-body-text-rgb), 0.25);
 			padding-block: var(--spacing-12);
 			padding-inline: 12px;
 			transition: box-shadow 0.2s, padding 0.2s;
+			box-shadow: 0 1px 5px 0 rgba(var(--color-body-text-rgb), 0.25);
 
 			// @media (prefers-color-scheme: dark) {
 			// 	box-shadow: 0 1px 5px 0 rgba(var(--color-body-bg-rgb), 0.75);

--- a/packages/ui/src/lib/components/info-box.svelte
+++ b/packages/ui/src/lib/components/info-box.svelte
@@ -4,26 +4,44 @@
 </script>
 
 <div class={`info ${cls}`}>
-	<slot />
+	<div class="content">
+		<slot name="content" />
+	</div>
+	{#if $$slots.buttons}
+		<div class="buttons">
+			<slot name="buttons" />
+		</div>
+	{/if}
 </div>
 
 <style lang="scss">
 	.info {
-		text-align: center;
 		padding-block: var(--spacing-24);
-		transition: padding 0.2s;
-
-		:global(p) {
-			margin-bottom: var(--spacing-6);
-		}
-
-		:global(.h2) {
-			margin-bottom: var(--spacing-12);
-		}
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		justify-content: flex-start;
+		gap: var(--spacing-48);
 
 		@media (min-width: 688px) {
 			padding-block: var(--spacing-48);
-			transition: padding 0.2s;
+		}
+		.content {
+			text-align: center;
+			display: flex;
+			flex-direction: column;
+			gap: var(--spacing-6);
+
+			:global(.icon) {
+				margin-bottom: var(--spacing-6);
+			}
+		}
+		.buttons:not(:empty) {
+			display: flex;
+			flex-direction: row;
+			align-items: center;
+			justify-content: center;
+			gap: var(--spacing-12);
 		}
 	}
 </style>

--- a/packages/ui/src/lib/components/info-box.svelte
+++ b/packages/ui/src/lib/components/info-box.svelte
@@ -5,7 +5,7 @@
 
 <div class={`info ${cls}`}>
 	<div class="content">
-		<slot name="content" />
+		<slot />
 	</div>
 	{#if $$slots.buttons}
 		<div class="buttons">

--- a/packages/ui/src/lib/components/info_screen.svelte
+++ b/packages/ui/src/lib/components/info_screen.svelte
@@ -1,14 +1,18 @@
 <script lang="ts">
 	import Header from '$lib/components/header.svelte'
 
+	let cls: string | undefined = undefined
+	let y: number
+	export { cls as class }
 	export let title: string
-
 	export let onBack: () => unknown = () => history.back()
 </script>
 
+<svelte:window bind:scrollY={y} />
+
 <Header {title} {onBack} />
 
-<div class="content">
+<div class={`content ${y > 0 ? 'scrolled' : ''} ${cls}`}>
 	<slot />
 
 	<div class="btns">
@@ -35,6 +39,13 @@
 			align-items: center;
 			justify-content: center;
 			gap: var(--spacing-12);
+		}
+
+		@media (min-width: 688px) {
+			min-height: calc(100vh - 140px);
+		}
+		&.scrolled {
+			min-height: calc(100vh - 68px);
 		}
 	}
 </style>

--- a/packages/ui/src/lib/components/persona_detail.svelte
+++ b/packages/ui/src/lib/components/persona_detail.svelte
@@ -254,6 +254,7 @@
 		justify-content: center;
 		align-items: center;
 		gap: var(--spacing-12);
+		flex-wrap: wrap;
 
 		@media (min-width: 688px) {
 			padding: var(--spacing-48);

--- a/packages/ui/src/lib/components/post.svelte
+++ b/packages/ui/src/lib/components/post.svelte
@@ -39,6 +39,7 @@
 		flex-wrap: nowrap;
 
 		div {
+			flex-basis: 100%;
 			img {
 				max-height: 300px;
 			}
@@ -48,23 +49,6 @@
 				width: 100%;
 				height: 100%;
 			}
-		}
-
-		/* one item */
-		div:first-child:nth-last-child(1) {
-			width: 100%;
-		}
-
-		/* two items */
-		div:first-child:nth-last-child(2),
-		div:first-child:nth-last-child(2) ~ div {
-			width: 50%;
-		}
-
-		/* three items */
-		div:first-child:nth-last-child(3),
-		div:first-child:nth-last-child(3) ~ div {
-			width: 33.3333%;
 		}
 	}
 

--- a/packages/ui/src/routes/persona/[id]/+page.svelte
+++ b/packages/ui/src/routes/persona/[id]/+page.svelte
@@ -43,9 +43,7 @@
 {#if persona === undefined}
 	<Container>
 		<InfoBox>
-			<svelte:fragment slot="content">
-				<div>There is no persona with group ID {$page.params.id}</div>
-			</svelte:fragment>
+			<div>There is no persona with group ID {$page.params.id}</div>
 		</InfoBox>
 	</Container>
 {:else}
@@ -108,17 +106,13 @@
 		{#if $posts.loading}
 			<Container>
 				<InfoBox>
-					<svelte:fragment slot="content">
-						<p>Loading posts...</p>
-					</svelte:fragment>
+					<p>Loading posts...</p>
 				</InfoBox>
 			</Container>
 		{:else if $posts.posts.length == 0}
 			<Container>
 				<InfoBox>
-					<svelte:fragment slot="content">
-						<p>There are no posts yet</p>
-					</svelte:fragment>
+					<p>There are no posts yet</p>
 				</InfoBox>
 			</Container>
 		{:else}

--- a/packages/ui/src/routes/persona/[id]/+page.svelte
+++ b/packages/ui/src/routes/persona/[id]/+page.svelte
@@ -9,6 +9,8 @@
 	import Grid from '$lib/components/grid.svelte'
 	import PersonaDetail from '$lib/components/persona_detail.svelte'
 	import Header from '$lib/components/header.svelte'
+	import Container from '$lib/components/container.svelte'
+	import InfoBox from '$lib/components/info-box.svelte'
 
 	import { posts } from '$lib/stores/post'
 	import { personas } from '$lib/stores/persona'
@@ -39,7 +41,13 @@
 <svelte:window bind:scrollY={y} />
 
 {#if persona === undefined}
-	<div>There is no persona with group ID {$page.params.id}</div>
+	<Container>
+		<InfoBox>
+			<svelte:fragment slot="content">
+				<div>There is no persona with group ID {$page.params.id}</div>
+			</svelte:fragment>
+		</InfoBox>
+	</Container>
 {:else}
 	<div class={`header ${y > 0 ? 'scrolled' : ''}`}>
 		<Header title={persona.name} {onBack}>
@@ -91,20 +99,32 @@
 		</svelte:fragment>
 
 		<svelte:fragment slot="button_other">
-			<!-- NEED TO ADD CORRECT ACTION HERE -->
+			<!-- TODO: NEED TO ADD CORRECT ACTION HERE -->
 			<Button label="Review pending" icon={Hourglass} />
 		</svelte:fragment>
 
-		<!-- PLACE FILTER COMPONENT HERE -->
+		<!-- TODO: PLACE FILTER COMPONENT HERE -->
 
 		{#if $posts.loading}
-			<p>Loading posts...</p>
+			<Container>
+				<InfoBox>
+					<svelte:fragment slot="content">
+						<p>Loading posts...</p>
+					</svelte:fragment>
+				</InfoBox>
+			</Container>
 		{:else if $posts.posts.length == 0}
-			<p>There are no posts yet</p>
+			<Container>
+				<InfoBox>
+					<svelte:fragment slot="content">
+						<p>There are no posts yet</p>
+					</svelte:fragment>
+				</InfoBox>
+			</Container>
 		{:else}
 			<Grid>
 				{#each $posts.posts as post}
-					<!-- NEEDS ONCLICK ACTION => SHOULD GO TO POST PAGE -->
+					<!-- TODO:  NEEDS ONCLICK ACTION => SHOULD GO TO POST PAGE -->
 					<Post {post} on:click />
 				{/each}
 			</Grid>

--- a/packages/ui/src/routes/persona/draft/[id]/+page.svelte
+++ b/packages/ui/src/routes/persona/draft/[id]/+page.svelte
@@ -107,21 +107,23 @@
 		<hr />
 		<Container>
 			<InfoBox>
-				{#if persona.posts.length < PERSONA_LIMIT}
-					<div class="icon-info">
-						<Info size={32} />
-					</div>
-					<p class="h2">{persona.posts.length} out {PERSONA_LIMIT} seed posts added</p>
-					<p>You need {PERSONA_LIMIT} seed posts to publish this Persona.</p>
-					<LearnMore href="/" />
-				{:else}
-					<div class="icon-success">
-						<Checkmark />
-					</div>
-					<p>{PERSONA_LIMIT} out {PERSONA_LIMIT} seed posts added</p>
-					<p>You can publish this Persona.</p>
-					<LearnMore href="/" />
-				{/if}
+				<svelte:fragment slot="content">
+					{#if persona.posts.length < PERSONA_LIMIT}
+						<div class="icon">
+							<Info size={32} />
+						</div>
+						<p class="h2">{persona.posts.length} out {PERSONA_LIMIT} seed posts added</p>
+						<p>You need {PERSONA_LIMIT} seed posts to publish this Persona.</p>
+						<LearnMore href="/" />
+					{:else}
+						<div class="icon icon-success">
+							<Checkmark />
+						</div>
+						<p>{PERSONA_LIMIT} out {PERSONA_LIMIT} seed posts added</p>
+						<p>You can publish this Persona.</p>
+						<LearnMore href="/" />
+					{/if}
+				</svelte:fragment>
 			</InfoBox>
 		</Container>
 		<Grid>

--- a/packages/ui/src/routes/persona/draft/[id]/+page.svelte
+++ b/packages/ui/src/routes/persona/draft/[id]/+page.svelte
@@ -107,23 +107,21 @@
 		<hr />
 		<Container>
 			<InfoBox>
-				<svelte:fragment slot="content">
-					{#if persona.posts.length < PERSONA_LIMIT}
-						<div class="icon">
-							<Info size={32} />
-						</div>
-						<p class="h2">{persona.posts.length} out {PERSONA_LIMIT} seed posts added</p>
-						<p>You need {PERSONA_LIMIT} seed posts to publish this Persona.</p>
-						<LearnMore href="/" />
-					{:else}
-						<div class="icon icon-success">
-							<Checkmark />
-						</div>
-						<p>{PERSONA_LIMIT} out {PERSONA_LIMIT} seed posts added</p>
-						<p>You can publish this Persona.</p>
-						<LearnMore href="/" />
-					{/if}
-				</svelte:fragment>
+				{#if persona.posts.length < PERSONA_LIMIT}
+					<div class="icon">
+						<Info size={32} />
+					</div>
+					<p class="h2">{persona.posts.length} out {PERSONA_LIMIT} seed posts added</p>
+					<p>You need {PERSONA_LIMIT} seed posts to publish this Persona.</p>
+					<LearnMore href="/" />
+				{:else}
+					<div class="icon icon-success">
+						<Checkmark />
+					</div>
+					<p>{PERSONA_LIMIT} out {PERSONA_LIMIT} seed posts added</p>
+					<p>You can publish this Persona.</p>
+					<LearnMore href="/" />
+				{/if}
 			</InfoBox>
 		</Container>
 		<Grid>

--- a/packages/ui/src/routes/persona/new/+page.svelte
+++ b/packages/ui/src/routes/persona/new/+page.svelte
@@ -44,14 +44,12 @@
 	<InfoScreen title="Leaving Persona creation" onBack={() => (showWarningModal = false)}>
 		<Container>
 			<InfoBox>
-				<svelte:fragment slot="content">
-					<div class="icon">
-						<Info size={32} />
-					</div>
-					<h2>Are you sure you want to leave?</h2>
-					<p>You are about to leave the persona creation screen.</p>
-					<p>WARNING: If you do so, all changes will be lost.</p>
-				</svelte:fragment>
+				<div class="icon">
+					<Info size={32} />
+				</div>
+				<h2>Are you sure you want to leave?</h2>
+				<p>You are about to leave the persona creation screen.</p>
+				<p>WARNING: If you do so, all changes will be lost.</p>
 				<svelte:fragment slot="buttons">
 					<Button
 						variant="secondary"
@@ -111,9 +109,7 @@
 		/>
 		<Container>
 			<InfoBox>
-				<svelte:fragment slot="content">
-					<p>Please provide a profile picture and a cover image.</p>
-				</svelte:fragment>
+				<p>Please provide a profile picture and a cover image.</p>
 			</InfoBox>
 		</Container>
 	</PersonaDetail>
@@ -121,18 +117,16 @@
 	<InfoScreen title="All changes saved">
 		<Container>
 			<InfoBox>
-				<svelte:fragment slot="content">
-					<div class="icon">
-						<Info size={32} />
-					</div>
-					<h2>This persona is saved as a draft (not public)</h2>
-					<p>
-						You will see it on your homepage. Before you can make it public you will need to create
-						5 “seed” posts. These posts should serve as inspiring examples for people willing to
-						post with this persona.
-					</p>
-					<LearnMore href="/" />
-				</svelte:fragment>
+				<div class="icon">
+					<Info size={32} />
+				</div>
+				<h2>This persona is saved as a draft (not public)</h2>
+				<p>
+					You will see it on your homepage. Before you can make it public you will need to create 5
+					“seed” posts. These posts should serve as inspiring examples for people willing to post
+					with this persona.
+				</p>
+				<LearnMore href="/" />
 				<svelte:fragment slot="buttons">
 					<Button variant="secondary" label="Continue later" on:click={() => history.back()} />
 					<Button
@@ -147,6 +141,3 @@
 		</Container>
 	</InfoScreen>
 {/if}
-
-<style lang="scss">
-</style>

--- a/packages/ui/src/routes/persona/new/+page.svelte
+++ b/packages/ui/src/routes/persona/new/+page.svelte
@@ -44,21 +44,30 @@
 	<InfoScreen title="Leaving Persona creation" onBack={() => (showWarningModal = false)}>
 		<Container>
 			<InfoBox>
-				<h2>Are you sure you want to leave?</h2>
-				<p>You are about to leave the persona creation screen</p>
-				<p>WARNING: If you do so, all changes will be lost.</p>
+				<svelte:fragment slot="content">
+					<div class="icon">
+						<Info size={32} />
+					</div>
+					<h2>Are you sure you want to leave?</h2>
+					<p>You are about to leave the persona creation screen.</p>
+					<p>WARNING: If you do so, all changes will be lost.</p>
+				</svelte:fragment>
+				<svelte:fragment slot="buttons">
+					<Button
+						variant="secondary"
+						label="Cancel"
+						icon={Close}
+						on:click={() => (showWarningModal = false)}
+					/>
+					<Button
+						icon={ArrowRight}
+						variant="primary"
+						label="Leave"
+						on:click={() => history.back()}
+					/>
+				</svelte:fragment>
 			</InfoBox>
 		</Container>
-
-		<svelte:fragment slot="buttons">
-			<Button
-				variant="secondary"
-				label="Cancel"
-				icon={Close}
-				on:click={() => (showWarningModal = false)}
-			/>
-			<Button icon={ArrowRight} variant="primary" label="Leave" on:click={() => history.back()} />
-		</svelte:fragment>
 	</InfoScreen>
 {:else if state === 'edit_text'}
 	<PersonaEditText
@@ -102,31 +111,40 @@
 		/>
 		<Container>
 			<InfoBox>
-				<p>Please provide a profile picture and a cover image.</p>
+				<svelte:fragment slot="content">
+					<p>Please provide a profile picture and a cover image.</p>
+				</svelte:fragment>
 			</InfoBox>
 		</Container>
 	</PersonaDetail>
 {:else}
 	<InfoScreen title="All changes saved">
-		<div>
-			<h1>This persona is saved as a draft (not public)</h1>
-			<p>
-				You will see it on your homepage. Before you can make it public you will need to create 5
-				“seed” posts. These posts should serve as inspiring examples for people willing to post with
-				this persona.
-			</p>
-			<LearnMore href="/" />
-		</div>
-		<svelte:fragment slot="buttons">
-			<Button variant="secondary" label="Continue later" on:click={() => history.back()} />
-			<Button
-				icon={ArrowRight}
-				variant="primary"
-				label="Proceed"
-				on:click={() =>
-					draftPersonaIndex !== undefined && goto(ROUTES.PERSONA_DRAFT(draftPersonaIndex))}
-			/>
-		</svelte:fragment>
+		<Container>
+			<InfoBox>
+				<svelte:fragment slot="content">
+					<div class="icon">
+						<Info size={32} />
+					</div>
+					<h2>This persona is saved as a draft (not public)</h2>
+					<p>
+						You will see it on your homepage. Before you can make it public you will need to create
+						5 “seed” posts. These posts should serve as inspiring examples for people willing to
+						post with this persona.
+					</p>
+					<LearnMore href="/" />
+				</svelte:fragment>
+				<svelte:fragment slot="buttons">
+					<Button variant="secondary" label="Continue later" on:click={() => history.back()} />
+					<Button
+						icon={ArrowRight}
+						variant="primary"
+						label="Proceed"
+						on:click={() =>
+							draftPersonaIndex !== undefined && goto(ROUTES.PERSONA_DRAFT(draftPersonaIndex))}
+					/>
+				</svelte:fragment>
+			</InfoBox>
+		</Container>
 	</InfoScreen>
 {/if}
 


### PR DESCRIPTION
header.svelte: update box shadow and title line height
info_screen.svelte: add scrolling class to center vertically properly in page
info-box.svelte: simplify styling and add named slots, update pages that use the component (persona/new, persona/draft/id)
post.svelte: simplify flexbox to show all images at the same size
persona/id: add Containers to wrap "loading” and "no posts to show” messages
persona/new: add styles to "saved as draft” info screen